### PR TITLE
fix: allow brand to be subclassed

### DIFF
--- a/src/Resources/config/doctrine/model/BrandImage.orm.xml
+++ b/src/Resources/config/doctrine/model/BrandImage.orm.xml
@@ -7,7 +7,7 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Loevgaard\SyliusBrandPlugin\Model\BrandImage" table="loevgaard_brand_image">
-        <many-to-one field="owner" target-entity="Loevgaard\SyliusBrandPlugin\Model\Brand" inversed-by="images">
+        <many-to-one field="owner" target-entity="Loevgaard\SyliusBrandPlugin\Model\BrandInterface" inversed-by="images">
             <join-column name="owner_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
     </mapped-superclass>


### PR DESCRIPTION
The current BrandImage doctrine mapping triggers schema validation errors when Brand is subclassed to add custom fields to the model.
Binding the owner field towards BrandInterface allows to use the doctrine mapping resolution configured by SyliusResourceBundle